### PR TITLE
[CMYK-254] feat: persist STT and TTS results to chat_history table

### DIFF
--- a/src/main/java/ego/websocketgateway/service/ChatHistoryJdbcSaver.java
+++ b/src/main/java/ego/websocketgateway/service/ChatHistoryJdbcSaver.java
@@ -20,6 +20,11 @@ public class ChatHistoryJdbcSaver {
 
 	public void save(ChatMessage msg, String type) {
 		String uid = "u".equals(type) ? msg.getFrom() : msg.getTo();
+
+		if(msg.getMessageHash() == null || msg.getMessageHash().isEmpty()){
+			msg.setMessageHash(ChatMessage.generateHash(uid, msg.getChatAt(), msg.getContent()));
+		}
+
 		String sql = String.format(
 			"INSERT INTO \"%s\".\"chat_history\" " +
 				"(uid, chat_room_id, content, type, content_type, chat_at, is_deleted, message_hash) " +
@@ -28,7 +33,7 @@ public class ChatHistoryJdbcSaver {
 		);
 
 		tenantJdbc.update(sql,
-			msg.getFrom(),
+			uid,
 			msg.getChatRoomId(),
 			msg.getContent(),
 			type.equals("u") ? "u" : "e",

--- a/src/main/java/ego/websocketgateway/service/KafkaStompBridge.java
+++ b/src/main/java/ego/websocketgateway/service/KafkaStompBridge.java
@@ -14,6 +14,16 @@ public class KafkaStompBridge {
 	private final SimpMessagingTemplate ws;
 	private final ChatHistoryJdbcSaver saver;
 
+	@KafkaListener(topics = "chat-client-responses", groupId = "gateway-group-client")
+	public void listenClient(ChatMessage msg) {
+		saver.save(msg, "u");
+	}
+
+	@KafkaListener(topics = "chat-ai-responses", groupId = "gateway-group-ai")
+	public void listenAI(ChatMessage msg) {
+		saver.save(msg, "e");
+	}
+
 	@KafkaListener(topics = "chat-responses", groupId = "gateway-group")
 	public void listen(ChatMessage msg) {
 		ws.convertAndSend("/topic/messages/" + msg.getTo(), msg);


### PR DESCRIPTION
### JIRA Task 🔖
- **Ticket**: [CMYK-254](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-254)
- **Branch** : feature/CMYK-254

### 작업 내용 📌

- 음성채팅 채팅방 파라미터 추가
- STT, TTS 결과 DB에 저장

### 결과 

| chat_history |
| --- |
| <img width="1318" alt="스크린샷 2025-05-25 17 04 44" src="https://github.com/user-attachments/assets/c9614957-d5e2-4995-bb3e-d3c31f01defa" /> |

[CMYK-254]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ